### PR TITLE
Quote JSON path in dashboard count command

### DIFF
--- a/scripts/dashboard-importer/upload.sh
+++ b/scripts/dashboard-importer/upload.sh
@@ -60,7 +60,7 @@ main() {
       JSON_PATH="$JSON_PATH/"
     fi
 
-    FILE_COUNT=$(find $1 -type f -name "*.json" | grep -v report.json | wc -l)
+    FILE_COUNT=$(find "$1" -type f -name "*.json" | grep -v report.json | wc -l)
 
     echo "Uploading $FILE_COUNT dashboard(s) from a directory with the following args:"
     echo -e "Directory: \033[34m$JSON_PATH\033[0m"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"5921072c-bcf1-451f-bd2f-3765d1bd2505","source":"chat","resourceId":"f2ee1adc-deb4-41b1-9394-98f744c74933","workflowId":"754ce2fa-ce8c-41aa-8cf3-39de1edcd901","codeChangeId":"754ce2fa-ce8c-41aa-8cf3-39de1edcd901","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/2e5836671382290397f779224edc72f4?panel_event_id=AwAAAZ8naCs6HZGn4wAAABhBWjhuYUNzNkFBQ1dMNDAxS0diU0MwRm4AAAAkZjE5ZjI3NmItYmMxMC00NmRjLTlkZGEtZTlkOTNkYjNiNDJmAABAPg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MmU1ODM2NjcxMzgyMjkwMzk3Zjc3OTIyNGVkYzcyZjR-M2ZlMTU1YjlhNzM4OThlYTIzMTc4YjAxODdmMzI3MWQ%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fmonitoring-dashboard-samples%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

Fixes a high-severity shell SAST finding by preventing word splitting and glob expansion when counting dashboard JSON files in the uploader script.

## Changes
- Updated `scripts/dashboard-importer/upload.sh` at the vulnerable command site.
- Changed `find $1 -type f -name "*.json" ...` to `find "$1" -type f -name "*.json" ...`.
- Kept behavior unchanged other than safe argument handling for paths containing spaces or glob characters.

## Testing
- Ran `bash -n scripts/dashboard-importer/upload.sh` to verify syntax.
- Reviewed `git diff -- scripts/dashboard-importer/upload.sh` to confirm a minimal one-line security fix.

## Security Impact
- Eliminates unsafe unquoted expansion at the reported finding location (`scripts/dashboard-importer/upload.sh:63`).
- Prevents unintended path splitting and wildcard expansion from user-supplied script arguments.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/f2ee1adc-deb4-41b1-9394-98f744c74933)

Comment @datadog to request changes