### PR TITLE
Quote JSON path expansion in upload script

### DIFF
--- a/scripts/dashboard-importer/upload.sh
+++ b/scripts/dashboard-importer/upload.sh
@@ -96,10 +96,10 @@ main() {
     fi
   elif [[ -f $JSON_PATH ]]; then
     # path provided is a single file
-    BASE_NAME=$(basename $JSON_PATH)
+    BASE_NAME=$(basename -- "$JSON_PATH")
     echo "Uploading json file: $BASE_NAME to project: $PROJECT..."
 
-    create_dashboard_with_gcloud $JSON_PATH
+    create_dashboard_with_gcloud "$JSON_PATH"
   else
     echo "path $JSON_PATH is not a directory or a JSON file"
   fi


### PR DESCRIPTION
<!-- dd-meta {"pullId":"afadda57-cc67-4724-9a2e-6eddb973e029","source":"chat","resourceId":"17bc3db4-ec6a-487e-a922-67b62716ec4a","workflowId":"8b44c019-fdbc-4a8e-86f7-674c51dfd305","codeChangeId":"8b44c019-fdbc-4a8e-86f7-674c51dfd305","sourceType":"code_security_sast"} -->
## Motivation

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/e3c9308450939dbab4a73cf4db6d74fd?panel_event_id=AwAAAZ8neMwzP68NuwAAABhBWjhuZU13ekFBRHczaTg4YUwwVlhIemIAAAAkZjE5ZjI3NzktNzZhNS00ZDZmLTlkNmQtNjg4ZTc3YTQ1NWZmAAAmPg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZTNjOTMwODQ1MDkzOWRiYWI0YTczY2Y0ZGI2ZDc0ZmR-M2ZlMTU1YjlhNzM4OThlYTIzMTc4YjAxODdmMzI3MWQ%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fmonitoring-dashboard-samples%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

The single-file upload path in `scripts/dashboard-importer/upload.sh` expanded `JSON_PATH` without quotes. That allows shell word splitting and glob expansion, which can mis-handle paths containing spaces or wildcard characters and trigger SAST findings.

## Changes
- Quote `JSON_PATH` when deriving the basename in the single-file branch.
- Add `--` to `basename` so paths beginning with `-` are treated as operands.
- Quote `JSON_PATH` when passing it to `create_dashboard_with_gcloud`.

## Testing
- Ran `bash -n scripts/dashboard-importer/upload.sh` to validate shell syntax after the changes.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/17bc3db4-ec6a-487e-a922-67b62716ec4a)

Comment @datadog to request changes