### PR TITLE
Quote vars in cloud-opts install script

### DIFF
--- a/terraform/agents/cloud-opts/scripts/install.sh
+++ b/terraform/agents/cloud-opts/scripts/install.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-curl -s ${script_endpoint} -o /tmp/agent.sh
+curl -s "${script_endpoint}" -o /tmp/agent.sh
 sudo bash /tmp/agent.sh \
   --also-install \
-  --version=${agent_version}
+  --version="${agent_version}"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"52f0cfd5-694b-4f42-8be8-673cfafe2bf9","source":"chat","resourceId":"324296d7-87ae-47cd-a5d3-7d1dfb967d82","workflowId":"71cb3d9e-6fa3-4e43-b52a-27b1ec9eeae1","codeChangeId":"71cb3d9e-6fa3-4e43-b52a-27b1ec9eeae1","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/7659d93b8c15f088f8813ac7babf78b3?panel_event_id=AwAAAZ8nuaPRV1HzkwAAABhBWjhudWFQUkFBQkdJQW9qVk9nVk5xQUIAAAAkZjE5ZjI3YmUtMjI2ZS00ZTVlLTgwZTItNjU3OGI0MTgwYWMwAABZgA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NzY1OWQ5M2I4YzE1ZjA4OGY4ODEzYWM3YmFiZjc4YjN-M2ZlMTU1YjlhNzM4OThlYTIzMTc4YjAxODdmMzI3MWQ%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fmonitoring-dashboard-samples%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

Fix a high-severity shell quoting issue in the cloud-opts Linux startup install script. Unquoted template variables could be split into multiple shell words or expanded as globs, which can alter `curl` and installer argument handling when Terraform inputs contain whitespace or wildcard characters.

## Changes
- Updated `terraform/agents/cloud-opts/scripts/install.sh` to quote `script_endpoint` in the `curl` invocation.
- Updated `terraform/agents/cloud-opts/scripts/install.sh` to quote `agent_version` in the installer `--version` argument.
- Kept the fix minimal and targeted to command argument safety without changing install behavior for valid values.

## Testing
- Ran `bash -n terraform/agents/cloud-opts/scripts/install.sh` to confirm script syntax is valid after the change.
- Inspected the file diff to verify only the vulnerable variable expansions were changed.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/324296d7-87ae-47cd-a5d3-7d1dfb967d82)

Comment @datadog to request changes