### PR TITLE
Quote dashboard uploader arguments

### DIFF
--- a/scripts/dashboard-importer/upload.sh
+++ b/scripts/dashboard-importer/upload.sh
@@ -88,7 +88,7 @@ main() {
       # Loop through JSONs and upload them via gcloud
       for file in $JSON_PATH/*.json; do
         if [[ ! "$file" =~ "report.json" ]]; then
-          create_dashboard_with_gcloud $file $UPLOAD_LOG
+          create_dashboard_with_gcloud "$file" "$UPLOAD_LOG"
         fi
       done
       echo
@@ -99,7 +99,7 @@ main() {
     BASE_NAME=$(basename $JSON_PATH)
     echo "Uploading json file: $BASE_NAME to project: $PROJECT..."
 
-    create_dashboard_with_gcloud $JSON_PATH
+    create_dashboard_with_gcloud "$JSON_PATH"
   else
     echo "path $JSON_PATH is not a directory or a JSON file"
   fi
@@ -122,4 +122,4 @@ then
   exit
 fi
 
-main $JSON_PATH $PROJECT
+main "$JSON_PATH" "$PROJECT"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"ea826b76-2cd2-46a0-a5de-8dded6d36652","source":"chat","resourceId":"b27c63ee-3d89-4ec7-b8d2-8c3112f9ea1b","workflowId":"0fda1414-e887-4907-bc22-9fcca7481dff","codeChangeId":"0fda1414-e887-4907-bc22-9fcca7481dff","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/933602649e38e34530d6efec57fc2833?panel_event_id=AwAAAZ8n5u7wzjKmeAAAABhBWjhuNXU3d0FBQUg2NlNRSXdIWTBJb0gAAAAkZjE5ZjI3ZTctNTRlNy00NGZmLWE1NGMtMjdkYmFkMDEyOTA4AABcNA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22OTMzNjAyNjQ5ZTM4ZTM0NTMwZDZlZmVjNTdmYzI4MzN-M2ZlMTU1YjlhNzM4OThlYTIzMTc4YjAxODdmMzI3MWQ%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fmonitoring-dashboard-samples%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

This change addresses a high-severity shell safety issue in the dashboard upload script by preventing word splitting and pathname expansion when passing file path arguments. Impact: dashboard JSON paths and upload log paths containing spaces or glob characters are now handled safely and predictably.

## Changes
- Quoted the `file` and `UPLOAD_LOG` arguments in the directory upload loop call to `create_dashboard_with_gcloud`.
- Quoted the single-file path argument when calling `create_dashboard_with_gcloud`.
- Quoted arguments when invoking `main` at script entry.

## Testing
- `bash -n scripts/dashboard-importer/upload.sh`
- Attempted `shellcheck scripts/dashboard-importer/upload.sh` (tool not installed in this environment).

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/b27c63ee-3d89-4ec7-b8d2-8c3112f9ea1b)

Comment @datadog to request changes