### PR TITLE
Quote dashboard upload shell variables

### DIFF
--- a/scripts/dashboard-importer/upload.sh
+++ b/scripts/dashboard-importer/upload.sh
@@ -22,21 +22,21 @@ create_dashboard_with_gcloud() {
   local UPLOAD_LOG=$2
 
   # Create the dashboard using gcloud. and store output into a variable
-  CREATE_LOG=$(gcloud monitoring dashboards create --project=$PROJECT --config-from-file=$FILE 2>&1)
+  CREATE_LOG=$(gcloud monitoring dashboards create --project="$PROJECT" --config-from-file="$FILE" 2>&1)
   # Parse out the Dashboard ID from the log output
-  DASHBOARD_ID=$(echo $CREATE_LOG | cut -d "[" -f2 | cut -d "]" -f1)
-  BASE_NAME=$(basename $FILE)
+  DASHBOARD_ID=$(printf '%s\n' "$CREATE_LOG" | cut -d "[" -f2 | cut -d "]" -f1)
+  BASE_NAME=$(basename "$FILE")
 
   # successful creation of a dashboard follows format of "Created [DASHBOARD_ID]."
   if [[ $CREATE_LOG =~ ^Created.* ]]; then
     echo
     echo -e "\033[32m✓ $BASE_NAME successfully uploaded: \033[0m\n\033[34mhttps://console.cloud.google.com/monitoring/dashboards/builder/$DASHBOARD_ID?project=$PROJECT\033[0m"
     if [ ! -z "$2" ]; then
-      echo "$BASE_NAME, https://console.cloud.google.com/monitoring/dashboards/builder/$DASHBOARD_ID?project=$PROJECT" >> $UPLOAD_LOG
+      echo "$BASE_NAME, https://console.cloud.google.com/monitoring/dashboards/builder/$DASHBOARD_ID?project=$PROJECT" >> "$UPLOAD_LOG"
     fi
   else
     echo "gcloud monitoring dashboards create resulted in unexpected output:"
-    echo $CREATE_LOG
+    printf '%s\n' "$CREATE_LOG"
     exit 1
   fi
 }


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3b129d9f-2f2a-4d18-9a96-951143af0d3e","source":"chat","resourceId":"8a41ff34-6638-47c7-9c96-2d7937ae972c","workflowId":"8dcb9a6c-4ab6-4137-8aff-06cbe06bbe72","codeChangeId":"8dcb9a6c-4ab6-4137-8aff-06cbe06bbe72","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/6ca4e74de4c81e33ad42c10fbd8694f0?panel_event_id=AwAAAZ8nbbBoF1Sb8QAAABhBWjhuYmJCb0FBQUdycWhIdVRZMlJfOW8AAAAkZjE5ZjI3NzktNzZhNS00ZDZmLTlkNmQtNjg4ZTc3YTQ1NWZmAAAnIw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NmNhNGU3NGRlNGM4MWUzM2FkNDJjMTBmYmQ4Njk0ZjB-M2ZlMTU1YjlhNzM4OThlYTIzMTc4YjAxODdmMzI3MWQ%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fmonitoring-dashboard-samples%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

This change fixes a high-severity shell expansion risk in the dashboard importer upload script. Unquoted variable expansion in command output parsing could trigger word splitting and glob expansion, leading to incorrect parsing and unintended file-name expansion.

## Changes
- Updated gcloud invocation to quote `PROJECT` and `FILE` arguments.
- Replaced unquoted `echo $CREATE_LOG` parsing with `printf '%s\n' "$CREATE_LOG"`.
- Quoted `basename` input and upload log redirection path in the same function.
- Replaced unquoted error-path log output with safe `printf` output.

## Testing
- Ran `bash -n scripts/dashboard-importer/upload.sh` (passes syntax validation).
- Manually reviewed diff scope to ensure changes are targeted to the vulnerable function only.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/8a41ff34-6638-47c7-9c96-2d7937ae972c)

Comment @datadog to request changes