### PR TITLE
Quote cloud-opts install script variables

### DIFF
--- a/terraform/agents/cloud-opts/scripts/install.sh
+++ b/terraform/agents/cloud-opts/scripts/install.sh
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-curl -s ${script_endpoint} -o /tmp/agent.sh
+curl -s "${script_endpoint}" -o /tmp/agent.sh
 sudo bash /tmp/agent.sh \
   --also-install \
-  --version=${agent_version}
+  --version="${agent_version}"


### PR DESCRIPTION
<!-- dd-meta {"pullId":"3bee3b88-2e56-4a84-8d37-36443e5761a0","source":"chat","resourceId":"4023f2e9-e466-4f86-9043-2952422c5708","workflowId":"8e151577-e13d-4ca0-8ae4-d0ada61ce070","codeChangeId":"8e151577-e13d-4ca0-8ae4-d0ada61ce070","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/7659d93b8c15f088f8813ac7babf78b3?panel_event_id=AwAAAZ8nuaPRV1HzkwAAABhBWjhudWFQUkFBQkdJQW9qVk9nVk5xQUIAAAAkZjE5ZjI3YmUtMjI2ZS00ZTVlLTgwZTItNjU3OGI0MTgwYWMwAABZgA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NzY1OWQ5M2I4YzE1ZjA4OGY4ODEzYWM3YmFiZjc4YjN-M2ZlMTU1YjlhNzM4OThlYTIzMTc4YjAxODdmMzI3MWQ%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fmonitoring-dashboard-samples%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

This change fixes a high-severity shell injection hardening issue in the cloud-opts Linux install startup script. Unquoted variable expansion in command arguments could trigger word splitting and glob expansion when variables are overridden.

## Changes
- Quoted `script_endpoint` in the `curl` invocation in `terraform/agents/cloud-opts/scripts/install.sh`.
- Quoted `agent_version` in the installer `--version` argument in `terraform/agents/cloud-opts/scripts/install.sh`.
- Kept behavior and script flow unchanged aside from safe argument handling.

## Testing
- Ran `bash -n terraform/agents/cloud-opts/scripts/install.sh` successfully.
- Reviewed the resulting diff to confirm only the intended lines were modified.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/4023f2e9-e466-4f86-9043-2952422c5708)

Comment @datadog to request changes