### PR TITLE
Quote JSON_PATH in dashboard importer

### DIFF
--- a/scripts/dashboard-importer/import.sh
+++ b/scripts/dashboard-importer/import.sh
@@ -25,7 +25,7 @@ then
 fi
 
 # Convert dashboards
-CONVERSION_OUTPUT=$(node dist/convert.js dashboards $JSON_PATH)
+CONVERSION_OUTPUT=$(node dist/convert.js dashboards "$JSON_PATH")
 echo "$CONVERSION_OUTPUT"
 
 # If project provided then upload the converted dashboard to the project


### PR DESCRIPTION
<!-- dd-meta {"pullId":"d70d0c15-5764-4575-9041-6b2746c12b78","source":"chat","resourceId":"e46b28c7-2c5c-4292-a48a-4cbfc1ec1260","workflowId":"29026cc9-b04d-428d-a1c7-98b6d9017834","codeChangeId":"29026cc9-b04d-428d-a1c7-98b6d9017834","sourceType":"code_security_sast"} -->
## Motivation/Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/0606d2eaf159f7ae5769d86f3b217c86?panel_event_id=AwAAAZ8nyqBzWJ6_OgAAABhBWjhueXFCekFBQjc5cHhUY0pOdThKRVIAAAAkZjE5ZjI3Y2ItZGQ0MC00MGU0LTk4ZjctZTQwMTZkOWUxN2UxAAAs7w&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MDYwNmQyZWFmMTU5ZjdhZTU3NjlkODZmM2IyMTdjODZ-M2ZlMTU1YjlhNzM4OThlYTIzMTc4YjAxODdmMzI3MWQ%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fmonitoring-dashboard-samples%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

The importer script passed JSON_PATH to node without quotes, which allows shell word splitting and glob expansion. This can mis-handle paths containing spaces or wildcard characters and trigger the SAST high-severity finding.

## Changes
- Updated scripts/dashboard-importer/import.sh to pass JSON_PATH as a single argument:
  - node dist/convert.js dashboards "$JSON_PATH"
- Kept behavior unchanged for normal paths while preventing splitting/expansion side effects.

## Testing/Validation
- Ran: bash -n scripts/dashboard-importer/import.sh
- Verified diff only contains the targeted quoting fix in import.sh.
- Attempted lint/format checks:
  - shellcheck not installed in this environment.
  - shfmt not installed in this environment.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/e46b28c7-2c5c-4292-a48a-4cbfc1ec1260)

Comment @datadog to request changes