### PR TITLE
Quote upload args to prevent shell splitting

### DIFF
--- a/scripts/dashboard-importer/upload.sh
+++ b/scripts/dashboard-importer/upload.sh
@@ -88,7 +88,7 @@ main() {
       # Loop through JSONs and upload them via gcloud
       for file in $JSON_PATH/*.json; do
         if [[ ! "$file" =~ "report.json" ]]; then
-          create_dashboard_with_gcloud $file $UPLOAD_LOG
+          create_dashboard_with_gcloud "$file" "$UPLOAD_LOG"
         fi
       done
       echo


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f8f070e1-d694-48ca-8ef5-37bfb951381b","source":"chat","resourceId":"6e7f4c83-46a0-4a7d-80c4-29b84fa2b910","workflowId":"bd97cf19-3bd8-4d93-b938-94d63ce9afbd","codeChangeId":"bd97cf19-3bd8-4d93-b938-94d63ce9afbd","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/933602649e38e34530d6efec57fc2833?panel_event_id=AwAAAZ8n5u7wzjKmeAAAABhBWjhuNXU3d0FBQUg2NlNRSXdIWTBJb0gAAAAkZjE5ZjI3ZTctNTRlNy00NGZmLWE1NGMtMjdkYmFkMDEyOTA4AABcNA&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22OTMzNjAyNjQ5ZTM4ZTM0NTMwZDZlZmVjNTdmYzI4MzN-M2ZlMTU1YjlhNzM4OThlYTIzMTc4YjAxODdmMzI3MWQ%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fmonitoring-dashboard-samples%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

Fix a shell expansion issue in the dashboard importer script so file paths are passed safely when uploading dashboards.

## Changes
- Quoted both arguments in the `create_dashboard_with_gcloud` call inside the JSON upload loop in `scripts/dashboard-importer/upload.sh`.
- Security impact: prevents unintended word splitting and glob expansion when file or log paths contain spaces or wildcard characters.

## Testing
- Ran `bash -n scripts/dashboard-importer/upload.sh` to verify script syntax after the change.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/6e7f4c83-46a0-4a7d-80c4-29b84fa2b910)

Comment @datadog to request changes