### PR TITLE
Quote JSON_PATH in dashboard importer

### DIFF
--- a/scripts/dashboard-importer/import.sh
+++ b/scripts/dashboard-importer/import.sh
@@ -25,7 +25,7 @@ then
 fi
 
 # Convert dashboards
-CONVERSION_OUTPUT=$(node dist/convert.js dashboards $JSON_PATH)
+CONVERSION_OUTPUT=$(node dist/convert.js dashboards "$JSON_PATH")
 echo "$CONVERSION_OUTPUT"
 
 # If project provided then upload the converted dashboard to the project


### PR DESCRIPTION
<!-- dd-meta {"pullId":"06e052f0-5003-463e-93f9-c1437118aa24","source":"chat","resourceId":"26ca4504-7688-4b68-bc9d-78450143bac0","workflowId":"88b142ca-5f96-46e7-a633-794329dd78b9","codeChangeId":"88b142ca-5f96-46e7-a633-794329dd78b9","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/0606d2eaf159f7ae5769d86f3b217c86?panel_event_id=AwAAAZ8nyqBzWJ6_OgAAABhBWjhueXFCekFBQjc5cHhUY0pOdThKRVIAAAAkZjE5ZjI3Y2ItZGQ0MC00MGU0LTk4ZjctZTQwMTZkOWUxN2UxAAAs7w&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22MDYwNmQyZWFmMTU5ZjdhZTU3NjlkODZmM2IyMTdjODZ-M2ZlMTU1YjlhNzM4OThlYTIzMTc4YjAxODdmMzI3MWQ%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fmonitoring-dashboard-samples%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

Fix a high-severity shell safety issue in the dashboard importer by preventing word-splitting and glob expansion when passing the user-provided JSON path to the converter.

## Changes
- Updated `scripts/dashboard-importer/import.sh` to quote `JSON_PATH` in the Node command invocation.
- This preserves the intended single-argument behavior for paths containing spaces or glob characters.

## Testing
- Ran `bash -n scripts/dashboard-importer/import.sh` to verify shell syntax.
- Attempted linting with `shellcheck`; it is not installed in this environment.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/26ca4504-7688-4b68-bc9d-78450143bac0)

Comment @datadog to request changes