### PR TITLE
Quote dashboard create log parsing

### DIFF
--- a/scripts/dashboard-importer/upload.sh
+++ b/scripts/dashboard-importer/upload.sh
@@ -24,7 +24,7 @@ create_dashboard_with_gcloud() {
   # Create the dashboard using gcloud. and store output into a variable
   CREATE_LOG=$(gcloud monitoring dashboards create --project=$PROJECT --config-from-file=$FILE 2>&1)
   # Parse out the Dashboard ID from the log output
-  DASHBOARD_ID=$(echo $CREATE_LOG | cut -d "[" -f2 | cut -d "]" -f1)
+  DASHBOARD_ID=$(printf '%s\n' "$CREATE_LOG" | cut -d "[" -f2 | cut -d "]" -f1)
   BASE_NAME=$(basename $FILE)
 
   # successful creation of a dashboard follows format of "Created [DASHBOARD_ID]."


### PR DESCRIPTION
<!-- dd-meta {"pullId":"040d7525-8e79-4aa9-8f19-8e09b1e439f1","source":"chat","resourceId":"2c5e0677-4f00-494e-8459-651198172413","workflowId":"bd0dd15b-ccbc-457d-a974-1bfa1e3918a5","codeChangeId":"bd0dd15b-ccbc-457d-a974-1bfa1e3918a5","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/6ca4e74de4c81e33ad42c10fbd8694f0?panel_event_id=AwAAAZ8nbbBoF1Sb8QAAABhBWjhuYmJCb0FBQUdycWhIdVRZMlJfOW8AAAAkZjE5ZjI3NzktNzZhNS00ZDZmLTlkNmQtNjg4ZTc3YTQ1NWZmAAAnIw&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22NmNhNGU3NGRlNGM4MWUzM2FkNDJjMTBmYmQ4Njk0ZjB-M2ZlMTU1YjlhNzM4OThlYTIzMTc4YjAxODdmMzI3MWQ%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fmonitoring-dashboard-samples%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

This change fixes a high-severity shell quoting issue in `scripts/dashboard-importer/upload.sh` when parsing `gcloud` command output. The previous unquoted expansion could trigger word splitting and pathname expansion.

## Changes
- Updated dashboard ID extraction to use a safely quoted pipeline:
  - from: `echo $CREATE_LOG | ...`
  - to: `printf '%s\n' "$CREATE_LOG" | ...`
- Kept the existing parsing behavior (`cut`) unchanged to minimize impact.

## Testing
- Ran: `bash -n scripts/dashboard-importer/upload.sh`
- Attempted `shellcheck`, but it is not available in this environment.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/2c5e0677-4f00-494e-8459-651198172413)

Comment @datadog to request changes