### PR TITLE
Quote JSON path in basename call

### DIFF
--- a/scripts/dashboard-importer/upload.sh
+++ b/scripts/dashboard-importer/upload.sh
@@ -96,7 +96,7 @@ main() {
     fi
   elif [[ -f $JSON_PATH ]]; then
     # path provided is a single file
-    BASE_NAME=$(basename $JSON_PATH)
+    BASE_NAME=$(basename "$JSON_PATH")
     echo "Uploading json file: $BASE_NAME to project: $PROJECT..."
 
     create_dashboard_with_gcloud $JSON_PATH


### PR DESCRIPTION
<!-- dd-meta {"pullId":"21f3a47f-5efb-42ab-95b8-60f47e1126b9","source":"chat","resourceId":"df154150-680b-445e-8a47-b8afca5244c3","workflowId":"6d21c23a-ac37-4c0e-82ab-9ad842af56e1","codeChangeId":"6d21c23a-ac37-4c0e-82ab-9ad842af56e1","sourceType":"code_security_sast"} -->
## Summary

Code Security (SAST) • [View in Code Security (SAST)](https://app.datadoghq.com/security/code-security/sast/vulnerability/e3c9308450939dbab4a73cf4db6d74fd?panel_event_id=AwAAAZ8neMwzP68NuwAAABhBWjhuZU13ekFBRHczaTg4YUwwVlhIemIAAAAkZjE5ZjI3NzktNzZhNS00ZDZmLTlkNmQtNjg4ZTc3YTQ1NWZmAAAmPg&query=%40finding_type%3Astatic_code_vulnerability+%40finding_id%3A%22ZTNjOTMwODQ1MDkzOWRiYWI0YTczY2Y0ZGI2ZDc0ZmR-M2ZlMTU1YjlhNzM4OThlYTIzMTc4YjAxODdmMzI3MWQ%3D%22+%40git.repository_id%3A%22github.com%2Froseteromeo56%2Fmonitoring-dashboard-samples%22+%22Double+quote+variable+expansions+to+prevent+word+splitting+and+glob+expansion%22)

Fix a shell quoting issue in the dashboard uploader script where a user-supplied path was expanded without quotes. This prevents word splitting and glob expansion when deriving the JSON file basename.

## Changes
- Updated `scripts/dashboard-importer/upload.sh` to quote `JSON_PATH` in the `basename` call at the single-file upload path.
- Kept script behavior unchanged for normal inputs while making path handling safe for spaces and wildcard characters.

## Testing
- Ran `bash -n scripts/dashboard-importer/upload.sh` (passes).
- Ran optional local tooling checks:
  - `shellcheck` not installed in this environment.
  - `shfmt` not installed in this environment.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/df154150-680b-445e-8a47-b8afca5244c3)

Comment @datadog to request changes